### PR TITLE
Add Supabase-based Next.js app with AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# codex-test
+# Codex Test
+
+This repository contains a simple Next.js app integrated with Supabase for authentication and an AI agent. The agent acts as a business strategist that reads documents from a Supabase vector store and uses OpenAI to answer questions.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   cd webapp
+   npm install
+   ```
+
+2. Set environment variables in `.env`:
+   ```bash
+   NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+   OPENAI_API_KEY=your-openai-key
+   ```
+
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+4. Visit `http://localhost:3000` in your browser.
+
+The `/api/agent` endpoint accepts a JSON body with a `query` field and returns an answer using the AI agent.

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/webapp/lib/supabaseClient.ts
+++ b/webapp/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/webapp/lib/useUser.ts
+++ b/webapp/lib/useUser.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+import { Session } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+export function useUser() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+    setSession(supabase.auth.session());
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return { session };
+}

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-supabase-ai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.0.0",
+    "openai": "^3.2.1",
+    "langchain": "^0.1.0"
+  }
+}

--- a/webapp/pages/_app.tsx
+++ b/webapp/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/webapp/pages/api/agent.ts
+++ b/webapp/pages/api/agent.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Configuration, OpenAIApi } from 'openai';
+import { supabase } from '../../lib/supabaseClient';
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { query } = req.body;
+  if (!query) {
+    return res.status(400).json({ error: 'query missing' });
+  }
+
+  // fetch vector data from Supabase
+  const { data: vectors } = await supabase
+    .from('documents')
+    .select('content, embedding')
+    .limit(10);
+
+  const prompt = `You are a business strategist AI. Use the following documents to answer:\n${vectors
+    ?.map((v: any) => v.content)
+    .join('\n')}\nQuestion: ${query}`;
+
+  const completion = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const answer = completion.data.choices[0].message?.content;
+  res.status(200).json({ answer });
+}

--- a/webapp/pages/index.tsx
+++ b/webapp/pages/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { useUser } from '../lib/useUser';
+
+export default function Home() {
+  const { session } = useUser();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const signIn = async () => {
+    setLoading(true);
+    await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+  };
+
+  const signUp = async () => {
+    setLoading(true);
+    await supabase.auth.signUp({ email, password });
+    setLoading(false);
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  if (!session) {
+    return (
+      <div style={{ padding: 20 }}>
+        <h1>Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button onClick={signIn} disabled={loading}>Sign In</button>
+        <button onClick={signUp} disabled={loading}>Sign Up</button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Welcome {session.user.email}</h1>
+      <button onClick={signOut}>Sign Out</button>
+    </div>
+  );
+}

--- a/webapp/styles/globals.css
+++ b/webapp/styles/globals.css
@@ -1,0 +1,1 @@
+body { margin: 0; font-family: sans-serif; }


### PR DESCRIPTION
## Summary
- add Next.js app scaffold with Supabase authentication
- implement business strategist AI agent API endpoint
- document setup instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e38f97aac832b9fa105255a516525